### PR TITLE
Embedding CLI into Mac App bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ swift package update
 rake xcodeproj
 ```
 
+## Compilation Instructions
+1) Install dependencies for CLI Version as instructed above
+2) Build using `waifu2x-mac-app` scheme 
+3) To locate the built macOS app, expand the Products folder on Project Navigator (left pane) and right click on `waifu2x-mac-app.app` to select **Show in Finder**
+4) This app can be dragged to any location you choose, such as `/Applications`
+5) If you would like to use the CLI version of `waifu2x-mac-app`, right click on the app and select `Show Package Contents`. Navigate to `Contents/MacOS`. The CLI version is `waifu2x`.
+6) Run `waifu2x` by navigating in a terminal to `waifu2x-mac-app.app/Contents/MacOS/` but if you would like to run the program anywhere, type in `ln -s /path/to/waifu2x /usr/local/bin/waifu2x`. You can also drag the `waifu2x` executable after `ln -s` to get the file path in terminal automatically.
+    - For example, if waifu2x-mac-app is in `/Applications`, you would run the following command to create an symbolic link: 
+       
+       `ln -s /Applications/waifu2x-mac-app.app/Contents/MacOS/waifu2x /usr/local/bin/waifu2x` 
+7) You can not drag the CLI executable out and use it directly as it will not work. You must create a symbolic link as shown above if you want to use it without going into the `waifu2x-mac-app.app` directory. Additionally the symbollic link will break if you move the macOS app. You can delete the old symbolic link in `/usr/local/bin` and run the `ln -s` command to create a new symbolic link.
+
+
 ## CLI Version Usage
 ```
 Usage: waifu2x [options]
@@ -31,4 +44,4 @@ Usage: waifu2x [options]
     -h, --help:
         Print usage
 ```
-**WARNING:** This CLI version is not a self-contained executable.  `CommandLineKit.framework` and `waifu2x_mac.framework` must be in the same directory as `waifu2x` executable in order to run. Refer to [this question](https://stackoverflow.com/questions/35423862/realm-swift-osx-cocoapods-sample-app-crashes) if you are interested in improving it. 
+**WARNING:** This CLI version is not a self-contained executable. `waifu2x` must be in `waifu2x-mac-app.app/Contents/MacOS/` with `CommandLineKit.framework` and `waifu2x_mac.framework` in `waifu2x-mac-app.app/Contents/Frameworks` or `CommandLineKit.framework` and `waifu2x_mac.framework` must be in the same directory as `waifu2x` executable in order to run. 

--- a/waifu2x-mac.xcodeproj/project.pbxproj
+++ b/waifu2x-mac.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5BA270B1219CFC760031CA9A /* CommandLineKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AACE77320D810DA0060240C /* CommandLineKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5BA270B5219CFC890031CA9A /* waifu2x in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8AC3DBEB20D82B6F00644896 /* waifu2x */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8AACE77A20D821B20060240C /* NSImage+PNG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC63CC9201878FA001498E0 /* NSImage+PNG.swift */; };
 		8AC3DBEE20D82B6F00644896 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3DBED20D82B6F00644896 /* main.swift */; };
 		8AC3DBF220D82B8700644896 /* waifu2x_mac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AC63C232018462E001498E0 /* waifu2x_mac.framework */; };
@@ -85,6 +87,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		5BA270B4219CFC800031CA9A /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				5BA270B5219CFC890031CA9A /* waifu2x in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8AC3DBE920D82B6F00644896 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -100,6 +112,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				5BA270B1219CFC760031CA9A /* CommandLineKit.framework in Embed Frameworks */,
 				8AC63CC420185D7D001498E0 /* waifu2x_mac.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -400,6 +413,7 @@
 				8AC63C522018466A001498E0 /* Frameworks */,
 				8AC63C532018466A001498E0 /* Resources */,
 				8AC63CC720185D7D001498E0 /* Embed Frameworks */,
+				5BA270B4219CFC800031CA9A /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -611,8 +625,9 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 34A2STWT5M;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/waifu2x_mac.framework/Versions/A/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/waifu2x_mac.framework/Versions/A/Frameworks @executable_path/../Frameworks";
 				PRODUCT_NAME = waifu2x;
+				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
 				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
 				SWIFT_VERSION = 4.0;
@@ -627,8 +642,9 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 34A2STWT5M;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/waifu2x_mac.framework/Versions/A/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/waifu2x_mac.framework/Versions/A/Frameworks @executable_path/../Frameworks";
 				PRODUCT_NAME = waifu2x;
+				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
 				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
 				SWIFT_VERSION = 4.0;


### PR DESCRIPTION
Changed the project.pbxproj file such that when the Mac app is compiled, the CLI version is also compiled and copied into the Mac App bundle into waifu2x-mac-app.app/Contents/MacOS. 

CommandLineKit.framework is also embedded into the Mac app when compiling the Mac app. This also means that the user will always have to run `swift package update` and `rake xcodeproj` in the Dependencies folder. Otherwise it will fail to build since CommandLineKit is missing. 

Finally I turned on `Skip install` for the CLI version since it wouldn't work if it is just copied into `/usr/local/bin`. The user can setup an alias on their own if they would like or we could add a script that specifies the creation of alias during build/install. That being said, I could be misunderstanding how `Skip install` works and I just know it is an option that affects Archiving.

Anyhow, this PR should allow the CLI to work 100% since it references the Frameworks in ../Frameworks and the Mac GUI App itself works as-is.