### PR TITLE
Bash script to build project

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ swift package update
 rake xcodeproj
 ```
 
+## Compilation Instructions
+1) Install dependencies for CLI Version as instructed above
+2) Build using `waifu2x-mac-app` scheme 
+3) To locate the built macOS app, expand the Products folder on Project Navigator (left pane) and right click on `waifu2x-mac-app.app` to select **Show in Finder**
+4) This app can be dragged to any location you choose, such as `/Applications`
+5) If you would like to use the CLI version of `waifu2x-mac-app`, right click on the app and select `Show Package Contents`. Navigate to `Contents/MacOS`. The CLI version is `waifu2x`.
+6) Run `waifu2x` by navigating in a terminal to `waifu2x-mac-app.app/Contents/MacOS/` but if you would like to run the program anywhere, type in `ln -s /path/to/waifu2x /usr/local/bin/waifu2x`. You can also drag the `waifu2x` executable after `ln -s` to get the file path in terminal automatically.
+    - For example, if waifu2x-mac-app is in `/Applications`, you would run the following command to create an symbolic link: 
+       
+       `ln -s /Applications/waifu2x-mac-app.app/Contents/MacOS/waifu2x /usr/local/bin/waifu2x` 
+7) You can not drag the CLI executable out and use it directly as it will not work. You must create a symbolic link as shown above if you want to use it without going into the `waifu2x-mac-app.app` directory. Additionally the symbollic link will break if you move the macOS app. You can delete the old symbolic link in `/usr/local/bin` and run the `ln -s` command to create a new symbolic link.
+
+
 ## CLI Version Usage
 ```
 Usage: waifu2x [options]
@@ -31,4 +44,4 @@ Usage: waifu2x [options]
     -h, --help:
         Print usage
 ```
-**WARNING:** This CLI version is not a self-contained executable.  `CommandLineKit.framework` and `waifu2x_mac.framework` must be in the same directory as `waifu2x` executable in order to run. Refer to [this question](https://stackoverflow.com/questions/35423862/realm-swift-osx-cocoapods-sample-app-crashes) if you are interested in improving it. 
+**WARNING:** This CLI version is not a self-contained executable. `waifu2x` must be in `waifu2x-mac-app.app/Contents/MacOS/` with `CommandLineKit.framework` and `waifu2x_mac.framework` in `waifu2x-mac-app.app/Contents/Frameworks` or `CommandLineKit.framework` and `waifu2x_mac.framework` must be in the same directory as `waifu2x` executable in order to run. 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Script to build the waifu2x-mac project (more) easily
+# Copyright (c) 2019 Mathieu Guimond-Morganti
+
+# Place this script at the root of the waifu2x-mac folder, then
+# chmod +x build.sh; ./build.sh;
+
+# Works with Xcode 10.1 and imxieyi/waifu2x-mac repo as of commit ca0088b (2018-11-17)
+# https://github.com/imxieyi/waifu2x-mac
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Change the working directory to the directory containing the script
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)
+
+# Check if the script is in the as directory as the Xcode project
+if [[ $(find . -name 'waifu2x-mac.xcodeproj' -d -maxdepth 1) ]]
+then
+
+    # Clean the base directory of previous build attempts
+    UNTRACKED=$(git clean -dffnx) # dry run
+    if [[ $UNTRACKED ]]
+    then
+        echo -e "$(tput bold)$(tput setaf 3)$(tput smul)Warning:$(tput sgr0)$(tput bold) The ${PWD##*/} directory will be cleaned of all untracked files.$(tput sgr0)"
+        echo "$UNTRACKED" # list of files to delete
+        read -n 1 -r -p "$(tput bold)$(tput smul)Are you sure?$(tput rmul) (y/n) $(tput sgr0)" CONFIRM
+        case $CONFIRM in
+            [Yy]* )
+                echo
+                git clean -dffx # delete ALL untracked files and folders to start anew
+                ;;
+            * ) # anything but Y cancels the operation
+                echo
+                echo "$(tput bold)$(tput setaf 1)$(tput smul)Error:$(tput sgr0)$(tput bold) Build cancelled.$(tput sgr0)"
+                exit 1
+                ;;
+        esac
+    fi
+
+    # Check for full Xcode.app
+    if ! [[ $(xcrun xcode-select -p | grep "\.app") ]] # Xcode.app is not the active developer directory
+    then
+        XCODEAPP=$(find /Applications -name 'Xcode*' -d -maxdepth 1 | head -n1) # Chooses Xcode.app over Xcode-beta.app if both are installed
+        if [[ $XCODEAPP ]]
+        then
+            echo "$(tput bold)$(tput setaf 3)$(tput smul)Warning:$(tput sgr0)$(tput bold) Selecting Xcode for command line tools (requires admin privileges).$(tput sgr0)"
+            sudo xcrun xcode-select -s $XCODEAPP/Contents/Developer # Set Xcode.app as the active developer directory
+            if ! [[ $(xcrun xcode-select -p | grep "\.app") ]] # still missing
+            then
+                echo "$(tput bold)$(tput setaf 1)$(tput smul)Error:$(tput sgr0)$(tput bold) Xcode is still not selected as the active developer directory.$(tput sgr0)"
+                echo "$(tput bold)If Xcode is installed, try the command: $(tput sgr0)sudo xcode-select -s $XCODEAPP/Contents/Developer"
+                exit # Fails if Xcode.app is not installed (Command Line Tools are not sufficient)
+            fi
+        else
+            echo "$(tput bold)$(tput setaf 1)$(tput smul)Error:$(tput sgr0)$(tput bold) Xcode is not installed.$(tput sgr0)"
+            echo "$(tput bold)Please download and install Xcode from: $(tput sgr0)$(tput smul)https://developer.apple.com/download/$(tput sgr0)"
+            exit 1 # Fails if Xcode.app is not installed (Command Line Tools are not sufficient)
+        fi
+    fi
+
+    # Check for required Ruby gem and install it if missing
+    if ! [[ $(gem list --local xcodeproj | grep xcodeproj) ]]
+    then
+        echo "$(tput bold)$(tput setaf 3)$(tput smul)Warning:$(tput sgr0)$(tput bold) Installing missing gem \"xcodeproj\" (requires admin privileges).$(tput sgr0)"
+        sudo gem install xcodeproj
+        if ! [[ $(gem list --local xcodeproj | grep xcodeproj) ]] # still missing
+        then
+            echo "$(tput bold)$(tput setaf 1)$(tput smul)Error:$(tput sgr0)$(tput bold) Ruby gem \"xcodeproj\" is still not installed.$(tput sgr0)"
+            echo "$(tput bold)If Ruby is installed, try the command: $(tput sgr0)sudo gem install xcodeproj"
+            exit 1 # Fails if xcodeproj is not installed (required to build command-line program)
+        fi
+    fi
+
+    # Configuring dependencies for command-line program
+    echo "$(tput bold)$(tput smul)Configuring...$(tput sgr0)"
+    cd Dependencies
+    swift package update
+    rake xcodeproj
+    cd ..
+
+    # Building with Xcode
+    echo "$(tput bold)$(tput smul)Building...$(tput sgr0)"
+    BUILD=$(xcodebuild clean build -quiet -scheme waifu2x-mac-app CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -derivedDataPath DerivedData)
+    if ! [[ $(mv ./DerivedData/Build/Products/Release ./build 2>&1) ]] # if success, the Release directory exists, so move it to a more convenient location
+    then
+        rm -r ./DerivedData
+        echo "$(tput bold)$(tput setaf 2)$(tput smul)Info:$(tput sgr0)$(tput bold) Build success.$(tput sgr0)"
+        ls -d -n1 build/* # show where the build is
+        exit 0
+    else
+        echo "$(tput bold)$(tput setaf 1)$(tput smul)Error:$(tput sgr0)$(tput bold) Build failed.$(tput sgr0)"
+        git clean -dffx # clean ALL untracked files and folders to start anew
+        exit 1
+    fi
+else # the script is not in the waifu2x-mac folder
+    echo "$(tput bold)$(tput setaf 1)This script must be placed in the same directory as \"waifu2x-mac.xcodeproj\".$(tput sgr0)"
+    exit 1
+fi
+exit 0

--- a/waifu2x-mac.xcodeproj/project.pbxproj
+++ b/waifu2x-mac.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5BA270B1219CFC760031CA9A /* CommandLineKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8AACE77320D810DA0060240C /* CommandLineKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5BA270B5219CFC890031CA9A /* waifu2x in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8AC3DBEB20D82B6F00644896 /* waifu2x */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8AACE77A20D821B20060240C /* NSImage+PNG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC63CC9201878FA001498E0 /* NSImage+PNG.swift */; };
 		8AC3DBEE20D82B6F00644896 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3DBED20D82B6F00644896 /* main.swift */; };
 		8AC3DBF220D82B8700644896 /* waifu2x_mac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AC63C232018462E001498E0 /* waifu2x_mac.framework */; };
@@ -85,6 +87,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		5BA270B4219CFC800031CA9A /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 6;
+			files = (
+				5BA270B5219CFC890031CA9A /* waifu2x in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8AC3DBE920D82B6F00644896 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -100,6 +112,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				5BA270B1219CFC760031CA9A /* CommandLineKit.framework in Embed Frameworks */,
 				8AC63CC420185D7D001498E0 /* waifu2x_mac.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -400,6 +413,7 @@
 				8AC63C522018466A001498E0 /* Frameworks */,
 				8AC63C532018466A001498E0 /* Resources */,
 				8AC63CC720185D7D001498E0 /* Embed Frameworks */,
+				5BA270B4219CFC800031CA9A /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -611,8 +625,9 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 34A2STWT5M;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/waifu2x_mac.framework/Versions/A/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/waifu2x_mac.framework/Versions/A/Frameworks @executable_path/../Frameworks";
 				PRODUCT_NAME = waifu2x;
+				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
 				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
 				SWIFT_VERSION = 4.0;
@@ -627,8 +642,9 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 34A2STWT5M;
-				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/waifu2x_mac.framework/Versions/A/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path @executable_path/waifu2x_mac.framework/Versions/A/Frameworks @executable_path/../Frameworks";
 				PRODUCT_NAME = waifu2x;
+				SKIP_INSTALL = YES;
 				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
 				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
 				SWIFT_VERSION = 4.0;


### PR DESCRIPTION
Pretty self-explanatory. I've added a rudimentary bash script to build the project automatically.

- Cleans the base directory of previous build attempts;
- Makes Xcode.app the active command line tools provider (required for `xcodebuild`);
- Installs Ruby gem `xcodeproj` if missing;
- Fetches dependencies for the CLI version;
- Builds the app with `xcodebuild`;
- Cleans leftover files if the build is successful.

It should help people who download this project but who don't know how to get started with it.